### PR TITLE
Capture output from pip commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Here's a list of things I plan to add or at least look into adding:
 
 - [ ] Include dependencies pip installs/updates in log of updated packages
 - [x] A log message when no packages need updated (at the moment it just looks like nothing happened)
-- [ ] A proper setup file
+- [x] A proper setup file
 - [ ] Allow running as a single command
-- [ ] Properly capture & hide terminal output from pip commands
+- [x] Properly capture & hide terminal output from pip commands
 - [ ] User config options
 - [ ] Dependency conflict management? (maybe) (possibly)

--- a/pipupdatercore/main.py
+++ b/pipupdatercore/main.py
@@ -66,7 +66,7 @@ def update_package(package: str, logger: Logger):
     :param logger: the logger instance
     """
     try:
-        subprocess.check_output(["pip", "install", "-U", package])
+        subprocess.run(["pip", "install", "-U", package], capture_output=True)
         success.append(package)
     except Exception as e:
         logger.new(f"Failed to update package: {package} ({e})", "ERROR")


### PR DESCRIPTION
This prevents the output from the pip subprocesses from showing up in the console. It also lays the groundwork for determining what dependencies were updated.
