### PR TITLE
Remove dependency on pip-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # pipupdater
 
-This is a small command-line tool designed for automatically updating pip packages based on the output of the pip-check module. The basic functionality is to pipe the output of `pip list --outdated --format=columns` to the `pipupdater` file, which will then attempt to extract the package names from the output and update all the modules.
+This is a small command-line tool designed for automatically updating outdated pip packages. The basic functionality is to pipe the output of `pip list --outdated` to the `pipupdater` file, which will then attempt to extract the package names from the output and update all the modules.
 
 This tool doesn't account for dependency conflicts and doesn't yet have any functionality for tracking what dependencies pip might have updated or installed itself. At the moment, it's very barebones due to being written in about half an hour by someone who was sicking of having to manually update each pip package.
 
 ## Requirements & installation
 
-Currently there is no setup file for this tool, but that's on the list. It depends on the `pip-check` module, which you can install through pip. I set it up by putting a symbolic link from where I have the git repo saved to my `~/.local/bin` folder. When I want to run it, I just do:
+Currently there is no setup file for this tool, but that's on the list. I set it up by putting a symbolic link from where I have the git repo saved to my `~/.local/bin` folder. When I want to run it, I just do:
 
-    pip list --outdated --format=columns | pipupdater
+    pip list --outdated | pipupdater
 
 (Actually, I have it aliased to `pipupdateall`. Same difference.)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     url="https://github.com/MurdoMaclachlan/pipupdater",
     packages=find_packages(),
     install_requires=[
-        "pip-check",
         "smooth_logger"
     ],
     classifiers=[


### PR DESCRIPTION
It's silly to write everything from the point-of-view of the pip-check module. pip can give you outdated packages itself and the existing method of extracting works on its format.
