### PR TITLE
Include version information in output log

### DIFF
--- a/pipupdatercore/main.py
+++ b/pipupdatercore/main.py
@@ -21,7 +21,51 @@ import sys
 from smooth_logger import Logger
 
 
-def print_results(failed: list[str], success: list[str], logger: Logger):
+def extract_package_details(line: str) -> list[str]:
+    """
+    Extracts the details of an outdated package from a given line. The details include the package
+    name, its current version, and the latest version available to update to.
+
+    :param line: the line to extract details from
+    :return: the package name, the current version and the latest version
+    """
+    # filter out empty characters for strings that use multiple spaces for formatting purposes
+    line_parts: list[str] = list(filter(lambda x: x != '', line.split(" ")))
+
+    package: str = line_parts[0]
+    current_version: str = None
+    latest_version: str = None
+
+    # handles default 'pip list --outdated' format
+    if line_parts[1] == "(Current:":
+        current_version = line_parts[2]
+        latest_version = line_parts[4].removesuffix(")")
+    # handles 'pip list --outdated format=columns' format
+    else:
+        current_version = line_parts[1]
+        latest_version = line_parts[2]
+
+    return [package, current_version, latest_version]
+
+
+def format_results(package_list: list[str]) -> str:
+    """
+    Formats a given list of packages to display in the following manner:
+
+        package_name (old_version -> new_version)
+    
+    :param package_list: the list of packages to format
+    :return: the formatted list
+    """
+    results: str = ""
+
+    for package in package_list:
+        results += f"   {package[0]} ({package[1]} -> {package[2]})\n"
+    
+    return results.removesuffix("\n")
+
+
+def print_results(failed: list[str], success: list[str], logger: Logger) -> None:
     """
     Outputs the results of the program.
 
@@ -31,19 +75,19 @@ def print_results(failed: list[str], success: list[str], logger: Logger):
     """
     if len(success) > 0:
         logger.new(
-            "The following packages were updated (list does not include auto-installed dependencies): "
-            + ', '.join(success),
+            "The following packages were updated (list does not include auto-installed dependencies):\n"
+            + format_results(success),
             "INFO"
         )
 
     if len(failed) > 0:
-        logger.new(f"Updates failed for the following packages: {', '.join(failed)}", "INFO")
+        logger.new(f"Updates failed for the following packages:\n{format_results(failed)}", "INFO")
 
     if len(success) == 0 and len(failed) == 0:
         logger.new("Nothing to do; did not find any out-of-date packages.", "INFO")
 
 
-def str_starts_with(string: str, prefixes: list[str]):
+def str_starts_with(string: str, prefixes: list[str]) -> bool:
     """
     Determines if a given string starts with any one of the given list of prefixes.
 
@@ -57,7 +101,10 @@ def str_starts_with(string: str, prefixes: list[str]):
     return False
 
 
-def update_package(package: str, failed: list[str], success: list[str], logger: Logger):
+def update_package(package_details: list[str],
+                   failed: list[str],
+                   success: list[str],
+                   logger: Logger) -> None:
     """
     Attempts to update a package with a given name, using subprocess.run() to execute a pip update
     command.
@@ -66,14 +113,14 @@ def update_package(package: str, failed: list[str], success: list[str], logger: 
     :param logger: the logger instance
     """
     try:
-        subprocess.run(["pip", "install", "-U", package], capture_output=True)
-        success.append(package)
+        subprocess.run(["pip", "install", "-U", package_details[0]], capture_output=True)
+        success.append(package_details)
     except Exception as e:
-        logger.new(f"Failed to update package: {package} ({e})", "ERROR")
-        failed.append(package)
+        logger.new(f"Failed to update package: {package_details[0]} ({e})", "ERROR")
+        failed.append(package_details)
 
 
-def pipupdater(prefixes: list[str], logger: Logger):
+def pipupdater(prefixes: list[str], logger: Logger) -> None:
     """
     The main function of pipupdater.
 
@@ -94,8 +141,10 @@ def pipupdater(prefixes: list[str], logger: Logger):
             logger.new(f"Skipping line: \"{line[:len(line)-1]}\"", "DEBUG") 
             continue
         
+        package_details: list[str] = extract_package_details(line)
+
         # installation is attempted simply by trying to install whatever comes before the first space
         # in the line, if there are any spaces
-        update_package(line.split(" ")[0], failed, success, logger)
+        update_package(package_details, failed, success, logger)
 
     print_results(failed, success, logger)


### PR DESCRIPTION
This update changes the formatting of the lists of updated/failed packages to show the old version and the version they were updated to / tried to update to.
