### PR TITLE
Fetch outdated packages as part of pipupdater runtime

### DIFF
--- a/pipupdater/__init__.py
+++ b/pipupdater/__init__.py
@@ -21,6 +21,3 @@ from .logger import Logger
 from .utility import str_starts_with
 
 from .pipupdater import *
-
-
-VERSION = "1.0.0-alpha"

--- a/pipupdater/logger.py
+++ b/pipupdater/logger.py
@@ -24,7 +24,6 @@ class Logger(smooth_logger.Logger):
     Extends the base smooth_logger.Logger class with some useful methods for formatting and
     printing the final output.
     """
-
     def format_results(self, package_list: list[str]) -> str:
         """
         Formats a given list of packages to display in the following manner:
@@ -52,7 +51,7 @@ class Logger(smooth_logger.Logger):
         if len(success) > 0:
             self.new(
                 "The following packages were updated (list does not include auto-installed "
-                + f"dependencies):\n{self.format_results(success)}"
+                + f"dependencies):\n{self.format_results(success)}",
                 "INFO"
             )
 


### PR DESCRIPTION
This PR closes #4.

This makes pipupdater run as a single command without any piping required from the user. The first thing pipupdater does upon starting its main method is to run `pip list --outdated` as a subprocess, capture the output, and use it to extract package details.