### PR TITLE
Save pip output to file if saving debug is enabled

### DIFF
--- a/pipupdater/logger.py
+++ b/pipupdater/logger.py
@@ -18,12 +18,34 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import smooth_logger
 
+from os import makedirs
+from os.path import isdir
+from smooth_logger.enums import Categories
+
 
 class Logger(smooth_logger.Logger):
     """
     Extends the base smooth_logger.Logger class with some useful methods for formatting and
     printing the final output.
     """
+    def __init__(self,
+                 program_name: str,
+                 config_path: str = None,
+                 debug: int = Categories.DISABLED,
+                 error: int = Categories.MAXIMUM,
+                 fatal: int = Categories.MAXIMUM,
+                 info: int = Categories.ENABLED,
+                 warning: int = Categories.MAXIMUM):
+        super().__init__(
+            program_name,
+            config_path,
+            debug,
+            error,
+            fatal,
+            warning,
+        )
+        self.save_path = self.__define_pip_save_path()
+
     def format_results(self, package_list: list[str]) -> str:
         """
         Formats a given list of packages to display in the following manner:
@@ -39,6 +61,29 @@ class Logger(smooth_logger.Logger):
             results += f"   {package[0]} ({package[1]} -> {package[2]})\n"
 
         return results.removesuffix("\n")
+
+    def __define_pip_save_path(self) -> str:
+        """
+        Determines the location for the pip log folder and creates it if it does not exist.
+
+        Returns None if an error arises while attempting to create the folder; this results in
+        saving pip logs being disabled for that instance of pipupdater.
+
+        :return: the location of the pip log folder
+        """
+        save_path: str = self._Logger__output_path.removesuffix("logs") + "pip_logs"
+        if not isdir(save_path):
+            self.new(f"Making pip log folder: {save_path}", "INFO")
+            try:
+                makedirs(save_path, exist_ok=True)
+            except Exception as e:
+                self.new(
+                    "Could not make pip log folder; saving pip output will be disabled for this"
+                    + f" instance. Error was: {e}",
+                    "ERROR"
+                )
+                return None
+        return save_path
 
     def print_results(self, failed: list[str], success: list[str]) -> None:
         """
@@ -63,3 +108,15 @@ class Logger(smooth_logger.Logger):
 
         if len(success) == 0 and len(failed) == 0:
             self.new("Nothing to do; did not find any out-of-date packages.", "INFO")
+
+    def save_pip_output(self, output: str) -> None:
+        """
+        Saves a given output string to the pip log file. Should be used only for saving the output
+        of pip command subprocesses.
+
+        :param output: the output to save
+        """
+        if self.save_path and self._Logger__scopes["DEBUG"] == Categories.MAXIMUM:
+            with open(f"{self.save_path}/pip_log-{self._Logger__get_time(method='date')}.txt",
+                      "at+") as save_file:
+                save_file.write(output)

--- a/pipupdater/pipupdater.py
+++ b/pipupdater/pipupdater.py
@@ -94,9 +94,10 @@ class Updater():
                 stderr=subprocess.STDOUT,
                 text=True
             )
+            self.logger.save_pip_output(process.stdout)
             return process.stdout.split("\n")
         except Exception as e:
-            self.logger.new(f"Could not get list of outdated packages. Error was:\n{e}", "FATAL")
+            self.logger.new(f"Could not get list of outdated packages. Error was: {e}", "FATAL")
             sys.exit(1)
 
     def update_all(self) -> None:
@@ -134,7 +135,13 @@ class Updater():
         :param logger: the logger instance
         """
         try:
-            subprocess.run(["pip", "install", "-U", package_details[0]], capture_output=True)
+            process: CompletedProcess = subprocess.run(
+                ["pip", "install", "-U", package_details[0]],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True
+            )
+            self.logger.save_pip_output(process.stdout)
             self.success.append(package_details)
         except Exception as e:
             self.logger.new(f"Failed to update package: {package_details[0]} ({e})", "ERROR")


### PR DESCRIPTION
Closes #22.

This is primarily a debug feature, so we'll limit it to working when the debug scope is set to maximum. Later commits will include command-line arguments for enabling debug statements.