### PR TITLE
Add PIPOUTPUT scope for managing pip output

### DIFF
--- a/pipupdater/logger.py
+++ b/pipupdater/logger.py
@@ -113,7 +113,7 @@ class Logger(smooth_logger.Logger):
 
         :param output: the output to save
         """
-        if self.save_path and self._scopes["DEBUG"] in [Categories.MAXIMUM, Categories.SAVE]:
+        if self.save_path and self._scopes["PIPOUTPUT"] == Categories.SAVE:
             with open(f"{self.save_path}/pip_log-{self._get_time(date_only=True)}.txt",
                       "at+") as save_file:
                 save_file.write(output)

--- a/pipupdater/pipupdater.py
+++ b/pipupdater/pipupdater.py
@@ -169,10 +169,8 @@ def entry_point():
     args: Namespace = get_args()
     config: dict[str, Any] = get_config(logger)
 
-    if args.debug:
-        logger.edit_scope("DEBUG", Categories.MAXIMUM)
-    elif args.save_pip:
-        logger.edit_scope("DEBUG", Categories.SAVE)
+    logger.edit_scope("DEBUG", Categories.MAXIMUM if args.debug else Categories.DISABLED)
+    logger.add_scope("PIPOUTPUT", Categories.SAVE if args.save_pip else Categories.DISABLED)
 
     updater: Updater = Updater(args, logger, config["prefixes"])
     updater.update_all()


### PR DESCRIPTION
This allows the output from pip subprocesses to be enabled without enabling debug logging and vice versa.

Closes #33.