### PR TITLE
Log packages as they are updated

### DIFF
--- a/pipupdater/models/Updater.py
+++ b/pipupdater/models/Updater.py
@@ -137,6 +137,7 @@ class Updater():
         :param logger: the logger instance
         """
         try:
+            self.logger.new(f"Updating package: {package_details[0]}...", "INFO")
             process: CompletedProcess = subprocess.run(
                 ["pip", "install", "-U", package_details[0]],
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
This update makes pipupdater produce a log message for each package as it is updated. This means that users will know which package is currently in process, in case of long update times.