### PR TITLE
Basic functionality for importing new config options

### DIFF
--- a/pipupdater/__init__.py
+++ b/pipupdater/__init__.py
@@ -15,12 +15,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 from .cmd import entry_point
 
 from .cfg import get_args
 from .cfg import get_config
-from .cfg import VERSION
+from .cfg import __version__
 
 from .helpers import str_starts_with
 

--- a/pipupdater/cfg.py
+++ b/pipupdater/cfg.py
@@ -17,6 +17,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import argparse
+import difflib
+import tomlkit
+import sys
 
 from .models import Logger
 
@@ -25,11 +28,11 @@ from importlib.resources import files
 from os import makedirs
 from os.path import exists
 from platformdirs import user_config_dir
-from tomllib import load, loads
-from typing import Any
+from tomlkit import TOMLDocument
+from typing import Any, List
 
 
-VERSION = "1.2.0-alpha"
+__version__ = "1.2.0-alpha"
 
 
 def get_args() -> Namespace:
@@ -49,13 +52,14 @@ def get_args() -> Namespace:
                         + " left blank, pipupdater will query pip for this list")
     parser.add_argument("-S", "--save-pip", action="store_true",
                         help="save pip output without printing it to console")
-    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {VERSION}")
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
 
     return parser.parse_args()
 
 
 def get_config(logger: Logger) -> dict[str, Any]:
-    """Get user config options. If the pipupdater config file doesn't exist, try to create it using
+    """
+    Get user config options. If the pipupdater config file doesn't exist, try to create it using
     the default config options. If not possible, use default config options for this run and warn
     the user that no config file exists.
 
@@ -69,16 +73,58 @@ def get_config(logger: Logger) -> dict[str, Any]:
             makedirs(config_folder)
 
         if exists(f"{config_folder}/config.toml"):
-            with open(f"{config_folder}/config.toml", "rb") as config_file:
-                return load(config_file)
+            with open(f"{config_folder}/config.toml", "r") as config_file:
+                return import_new_config(tomlkit.load(config_file), config_folder, logger)
         else:
             with open(f"{config_folder}/config.toml", "w+") as config_file:
                 default: str = files('pipupdater.data').joinpath('default_config.toml').read_text()
                 config_file.write(default)
-                return loads(default)
+                return tomlkit.loads(default).unwrap()
     except Exception as e:
         logger.new(
             "Could not find existing config file or make a new one. Using default settings.",
             "WARNING"
         )
-        return loads(files('pipupdater.data').joinpath('default_config.toml').read_text())
+        return tomlkit.loads(
+            files('pipupdater.data').joinpath('default_config.toml').read_text()
+        ).unwrap()
+
+
+def import_new_config(
+        existing: TOMLDocument,
+        config_folder: str,
+        logger: Logger) -> dict[str, Any]:
+    """
+    Compares the default_config.toml file with the user's existing configuration file (if one
+    exists). Any keys missing from the user's file will be imported from the default and written
+    to the existing file.
+
+    Strictly speaking, this function imports the existing configuration options into the default
+    config file.
+
+    Presently, this function does not support importing new entries in existing arrays, only entirely
+    new keys, and consequently new default prefixes cannot be imported. This functionality will be
+    added in a future update.
+
+    :param existing: the existing config options
+    :returns: the modified config options
+    """
+    modified: bool = False
+    default: TOMLDocument = tomlkit.loads(
+        files('pipupdater.data').joinpath('default_config.toml').read_text()
+    )
+
+    if (default.as_string() != existing.as_string()):
+        default.update(existing)
+        modified = True
+
+    if modified:
+        logger.new(
+            "New configuration options were detected in the default config file. Adding them to"
+            + " existing config.",
+            "INFO"
+        )
+        with open(f"{config_folder}/config.toml", "w+") as config_file:
+            tomlkit.dump(default, config_file)
+    
+    return default


### PR DESCRIPTION
This adds the ability to import entirely config keys if they are detected in the packaged default_config.toml file. It does not presently support importing new items in lists if the key for the list already existed. That functionality will be added at a later date.

Contributes to #40, but doesn't fully close it.