### PR TITLE
Add config options for DEBUG and PIPOUTPUT scopes

### DIFF
--- a/pipupdater/__init__.py
+++ b/pipupdater/__init__.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 from .cmd import entry_point
 
 from .cfg import get_args

--- a/pipupdater/data/default_config.toml
+++ b/pipupdater/data/default_config.toml
@@ -1,7 +1,6 @@
 # This is the config file for the 'pipupdater' program. You can edit the values below to modify the
 # behaviour of the program.
 
-
 # The prefixes that pipupdater uses to recognise lines that should be skipped in the output of pip
 # subprocesses. Lines starting with these strings won't be scanned for package upgrades.
 prefixes = [
@@ -11,3 +10,9 @@ prefixes = [
     "Package ",
     "-------"
 ]
+
+# Default settings for scope levels in the Logger. If either of these are set to true, they will
+# be enabled even if their corresponding command-line flag is not passed at runtime.
+[logger]
+debug = false        # corresponding flag: --debug
+pipoutput = false    # corresponding flag: --save-pip


### PR DESCRIPTION
Adds options in the config file for whether the DEBUG and PIPOUTPUT scopes in the Logger should be enabled by default. This allows the --debug or --save-pip flag to be enabled by default for users who want them to be.

Closes #36.