### PR TITLE
Fix new config options not actually doing anything

### DIFF
--- a/pipupdater/__init__.py
+++ b/pipupdater/__init__.py
@@ -20,6 +20,7 @@ from .cmd import entry_point
 
 from .cfg import get_args
 from .cfg import get_config
+from .cfg import modify_args
 from .cfg import __version__
 
 from .helpers import str_starts_with

--- a/pipupdater/cfg.py
+++ b/pipupdater/cfg.py
@@ -91,6 +91,22 @@ def get_config(logger: Logger) -> dict[str, Any]:
         ).unwrap()
 
 
+def modify_args(args: Namespace, config: dict[str, Any]) -> Namespace:
+    """
+    Modifies the args Namespace with values imported from the config file. This method will always
+    overwrite False variables, but never True ones; that is, if --debug is not passed, but debug is
+    true in the config file, it will be set to True, but if --debug *is* passed and is false in the
+    config file, it will not be set to False in runtime.
+
+    :param args: the command-line arguments
+    :param config: the config file data
+    :returns: the modified args Namespace
+    """
+    if config["logger"]["debug"]: args.debug = True
+    if config["logger"]["pipoutput"]: args.save_pip = True
+    return args
+
+
 def import_new_config(
         existing: TOMLDocument,
         config_folder: str,

--- a/pipupdater/cmd.py
+++ b/pipupdater/cmd.py
@@ -20,6 +20,7 @@ import shutil
 
 from .cfg import get_args
 from .cfg import get_config
+from .cfg import modify_args
 from .models import Logger
 from .models import Updater
 
@@ -36,6 +37,8 @@ def entry_point():
 
     args: Namespace = get_args()
     config: dict[str, Any] = get_config(logger)
+
+    args = modify_args(args, config)
 
     logger.edit_scope("DEBUG", Categories.MAXIMUM if args.debug else Categories.DISABLED)
     logger.add_scope("PIPOUTPUT", Categories.SAVE if args.save_pip else Categories.DISABLED)


### PR DESCRIPTION
I forgot to make the program use the new Logger config options. This adds a small method that overwrites their corresponding argument flag to True if they are also True, but does nothing if they are False.